### PR TITLE
Subtle changing of file names and locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN \
  /app/kanzi/ && \
  cd /app/kanzi && \
  echo ${KANZI_RELEASE} > version.txt && \
- touch /app/kanzi/deployed.txt && \
+ touch /app/kanzi/deployed-kanzi.txt && \
  pip install --no-cache-dir pip==9.0.3 && \
  pip install -r \
     requirements.txt \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -42,7 +42,7 @@ RUN \
  /app/kanzi/ && \
  cd /app/kanzi && \
  echo ${KANZI_RELEASE} > version.txt && \
- touch /app/kanzi/deployed.txt && \
+ touch /app/kanzi/deployed-kanzi.txt && \
  pip install --no-cache-dir pip==9.0.3 && \
  pip install -r \
     requirements.txt \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -42,7 +42,7 @@ RUN \
  /app/kanzi/ && \
  cd /app/kanzi && \
  echo ${KANZI_RELEASE} > version.txt && \
- touch /app/kanzi/deployed.txt && \
+ touch /app/kanzi/deployed-kanzi.txt && \
  pip install --no-cache-dir pip==9.0.3 && \
  pip install -r \
     requirements.txt \

--- a/root/etc/cont-init.d/20-certs
+++ b/root/etc/cont-init.d/20-certs
@@ -1,12 +1,12 @@
 #!/usr/bin/with-contenv bash
 
 # make our folders
-[[ ! -d /config/keys ]] && \
+[[ ! -d /config/keys/kanzi ]] && \
 mkdir -p \
-	/config/keys
+	/config/keys/kanzi
 
 # create keys
-[[ ! -e /config/keys/certificate.pem ]] && \
+[[ ! -e /config/keys/kanzi/certificate.pem ]] && \
 	openssl req -x509 -nodes -days 3650 \
-	-newkey rsa:2048 -keyout /config/keys/private-key.pem  -out /config/keys/certificate.pem \
+	-newkey rsa:2048 -keyout /config/keys/kanzi/private-key.pem  -out /config/keys/kanzi/certificate.pem \
 	-subj "/CN=kanzi"

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,8 +1,8 @@
 #!/usr/bin/with-contenv bash
 
 # Copy deployed.txt file to /config
-[[ ! -f /config/deployed.txt ]] && \
-    cp /app/kanzi/deployed.txt /config/deployed.txt
+[[ ! -f /config/deployed-kanzi.txt ]] && \
+    cp /app/kanzi/deployed-kanzi.txt /config/deployed-kanzi.txt
 
 # Create dummy cli_config
 [[ ! -f /config/cli_config ]] && \
@@ -31,7 +31,7 @@
 
 #Necessary variables
 KANZI_VERSION=$(cat /app/kanzi/version.txt)
-DEPLOYED_VERSION=$(cat /config/deployed.txt)
+DEPLOYED_VERSION=$(cat /config/deployed-kanzi.txt)
 
 # Check for credentials in cli_config
 grep -q token /config/cli_config
@@ -49,7 +49,7 @@ if [ $? != 0 ]
        lexigram init-skill kanzi
      fi
      lexigram deploy kanzi --source-dir /app/kanzi --invocation-name ${INVOCATION_NAME} --url ${URL_ENDPOINT} && \
-     echo "${KANZI_VERSION}" > /config/deployed.txt && \
+     echo "${KANZI_VERSION}" > /config/deployed-kanzi.txt && \
      echo "    Kanzi ${KANZI_VERSION} successfully deployed with invocation name ${INVOCATION_NAME} at ${URL_ENDPOINT}"
    fi
 fi

--- a/root/etc/services.d/kanzi/run
+++ b/root/etc/services.d/kanzi/run
@@ -3,4 +3,4 @@
 cd /app/kanzi || exit
 
 exec \
-	s6-setuidgid abc gunicorn -b 0.0.0.0:8000 --certfile /config/keys/certificate.pem --keyfile /config/keys/private-key.pem alexa:app
+	s6-setuidgid abc gunicorn -b 0.0.0.0:8000 --certfile /config/keys/kanzi/certificate.pem --keyfile /config/keys/kanzi/private-key.pem alexa:app


### PR DESCRIPTION
Started working on companion skill to this one, from the same author, no reason why they shouldn't share the host mount at `/config` but need to rename/move some files.  Means users will only need to edit one instance of `kodi.config` and authorise with Amazon once rather than twice.